### PR TITLE
Handle nan's better in vMF loss

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -50,13 +50,10 @@ def eval(model, loss_function, test_iter, args, ignore_index=-100) -> Any:
         attn_vectors = torch.stack(model.decoder.attention).permute(1,0,2)
         mask = (batch.trg[1:,:].view(-1) != ignore_index)
         if is_vmf_loss:
-            # Remove first elem of batch.trg which is start token.
             target = model.decoder.embedding(batch.trg[1:,:].view(-1))
-            raw_loss = loss_function(scores[:-1,:,:].view(-1, scores.shape[2]), target)
-            loss = (raw_loss * mask).sum() / mask.sum()
         else:
             target = batch.trg[1:,:].view(-1)
-            loss = loss_function(scores[:-1,:,:].view(-1, scores.shape[2]), target)
+        loss = loss_function(scores[:-1,:,:].view(-1, scores.shape[2]), target)
         loss_tot += loss.item()
         if is_vmf_loss:
             pred_embeds = scores[:-1,:,:]

--- a/loss.py
+++ b/loss.py
@@ -23,7 +23,6 @@ class VonMisesFisherLoss(torch.nn.modules.loss._Loss):
         reduction="mean",
         use_finite_sums=False,
         device: str = "cpu",
-        ignore_index=-100,
     ) -> None:
         super(VonMisesFisherLoss, self).__init__(reduction=reduction)
         self.lambda_1 = lambda_1

--- a/loss.py
+++ b/loss.py
@@ -41,9 +41,16 @@ class VonMisesFisherLoss(torch.nn.modules.loss._Loss):
             self.get_normalizing_const = self._nc_lower_bound
 
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
+        """
+        Note: if `reduction` is `"none"`, this loss function will return inccorect
+        values for which the `target` is a zero vector. They should be filtered out
+        before aggregation and backpropagation.
+        """
         # Only the target and not the input vector must have unit norm
-        unit_target = target / target.norm(dim=-1).reshape(-1, 1)
-        # Second line is batch-wise dot product
+        target_norms = target.norm(dim=-1)
+        zero_mask = target_norms != 0.0
+        # Add 1 to the 0's lest we get nan's which will ruin backward()
+        unit_target = target / (target_norms + ~zero_mask).unsqueeze(-1)
         input_norm = input.norm(dim=-1)
         x = (
             -self.get_normalizing_const(input_norm, input.shape[-1])
@@ -53,9 +60,9 @@ class VonMisesFisherLoss(torch.nn.modules.loss._Loss):
         if self.reduction == "none":
             return x
         elif self.reduction == "mean":
-            return x.mean()
+            return x[zero_mask].sum() / zero_mask.sum()
         elif self.reduction == "sum":
-            return x.sum()
+            return x[zero_mask].sum()
 
     def _nc_lower_bound(self, kappa: Tensor, m: Tensor) -> Tensor:
         v = m / 2

--- a/main.py
+++ b/main.py
@@ -137,7 +137,7 @@ if __name__ == '__main__':
                 device=args["device"],
                 lambda_1=args["vmf_lambda_1"],
                 lambda_2=args["vmf_lambda_2"],
-                reduction="none",
+                reduction="mean",
             )
         else:
             raise ValueError(f"Unknown loss function: {args['loss_function']}")

--- a/train.py
+++ b/train.py
@@ -20,12 +20,9 @@ def train(model, optimizer, scheduler, loss_function, train_iter, val_iter, args
             scores = model(batch.src, batch.trg)
             if isinstance(loss_function, VonMisesFisherLoss):
                 target = model.decoder.embedding(batch.trg[1:,:].view(-1))
-                raw_loss = loss_function(scores[:-1,:,:].view(-1, scores.shape[2]), target)
-                mask = (batch.trg[1:,:].view(-1) != ignore_index)
-                loss = (raw_loss * mask).sum() / mask.sum()
             else:
                 target = batch.trg[1:,:].view(-1)
-                loss = loss_function(scores[:-1,:,:].view(-1, scores.shape[2]), target)
+            loss = loss_function(scores[:-1,:,:].view(-1, scores.shape[2]), target)
             loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), args['gradient_clipping'])
             optimizer.step()


### PR DESCRIPTION
So one option would be to pass vMF loss indices as well as embeddings and filter them out using that method -- that is _not_ what I did here. I took the other route and exclude any vectors that are completely 0.

The reason why I have to use this somewhat confusing code to filter out `nan`s is because even if I index only non-nan values, the nan's will still mess up `backward()` so I have fill them with dummy values and exclude the dummy values with indexing. This is necessary because presumably when `backward()` sees that the gradient is 0, it does `0 * nan == nan`.