### PR TITLE
Unk init fix

### DIFF
--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,11 +1,10 @@
-python main.py --checkpoint_path sm_deen_small\
-               --device cuda:3\
+python main.py --checkpoint_path vmf\
+               --loss_function vmf\
+               --device cuda\
                --src_language de\
                --trg_language en\
                --enc_bidirectional\
                --input_feed\
                --tie_embed\
                --unk_replace\
-               --trg_fasttext_embeds\
-               --max_len 20\
-               --min_freq 2
+               --fasttext_embeds_path ~/data/corpus.fasttext.txt

--- a/utils.py
+++ b/utils.py
@@ -79,17 +79,15 @@ def torchtext_iterators(args, src_vocab=None, trg_vocab=None):
     if args['fasttext_embeds_path'] is not None:
         embedding_vectors = torchtext.vocab.Vectors(name=args['fasttext_embeds_path'])
         trg_field.vocab.load_vectors(vectors=embedding_vectors)
-        if args['loss'] == 'vmf':
+        if args['loss_function'] == 'vmf':
             # Intialize UNK to the negative mean of the vectors of words not in vocab.
-            full_vocab = torchtext.data.Field()
-            full_vocab.build_vocab(train.trg, min_freq=args['min_freq'])
-            excluded_words = [word for word in full_vocab.vocab.stoi if word not in trg_field.vocab.stoi]
+            excluded_words = [word for word in embedding_vectors.stoi if word not in trg_field.vocab.stoi]
             if excluded_words:
                 excluded_vectors = torch.stack(
                     [embedding_vectors[excluded_word] for excluded_word in excluded_words\
                         if excluded_word in embedding_vectors.stoi]
                 )
-                unk_vector = -torch.mean(excluded_vectors,dim=0)
+                unk_vector = -torch.mean(excluded_vectors, dim=0)
             else:
                 unk_vector = torch.randn(trg_field.vocab.vectors[trg_field.vocab.stoi[UNK_TOKEN]].shape)
             trg_field.vocab.vectors[trg_field.vocab.stoi[UNK_TOKEN]] = unk_vector


### PR DESCRIPTION
I might be wrong in the interpretation.
Show the unk be initialized to the average of all embeddings in fasttext that are not the vocab?
Currently it is the average of embeddings of words in the corpus that are not part of the vocab.